### PR TITLE
Changed cout to endl, was causing build to fail

### DIFF
--- a/scripts/devantech_change_addr.cpp
+++ b/scripts/devantech_change_addr.cpp
@@ -12,7 +12,7 @@
 int main (int argc, char *argv[]) 
 {
     if (argc != 4) {
-        std::cout << "Invalid number of arguments. " << argc << std::cout;
+        std::cout << "Invalid number of arguments. " << argc << std::endl;
         return -1;
     }
     char *end;
@@ -29,7 +29,7 @@ int main (int argc, char *argv[])
     new_addr = new_addr << 1;
     
     if (new_addr < 0xE0 || new_addr > 0xEE) {
-        std::cout << "Unsupported new address." << std::cout;
+        std::cout << "Unsupported new address." << std::endl;
         return -1;
     }
     int file = open(filename, O_RDWR);


### PR DESCRIPTION
On line 15 and 32, lines were ended by std::cout instead of std::endl.
This was causing the build to fail.
-DIT168 Group9